### PR TITLE
Removed Friends!

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.6-SNAPSHOT'
+	id 'fabric-loom' version '1.7-SNAPSHOT'
 	id 'maven-publish'
 }
 
@@ -19,6 +19,12 @@ repositories {
 	maven {
 		name = 'henkelmax.public'
 		url = 'https://maven.maxhenkel.de/repository/public'
+	}
+	maven {
+		url = "https://api.modrinth.com/maven"
+		content {
+			includeGroup "maven.modrinth"
+		}
 	}
 }
 
@@ -45,6 +51,10 @@ dependencies {
 
 	// Fabric API. This is technically optional, but you probably want it anyway.
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+
+
+	// FischyFriends API. Required for private waypoints to work correctly
+	modCompileOnly "maven.modrinth:fischy-friends:${project.friends_version}"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,4 @@ archives_base_name=cimple-waypoint-system
 
 # Dependencies
 fabric_version=0.100.3+1.21
+friends_version=1.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,4 @@ archives_base_name=cimple-waypoint-system
 
 # Dependencies
 fabric_version=0.100.3+1.21
-friends_version=1.0.0
+friends_version=1.1.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/com/cimadev/cimpleWaypointSystem/Config.java
+++ b/src/main/java/com/cimadev/cimpleWaypointSystem/Config.java
@@ -16,7 +16,6 @@ import static com.cimadev.cimpleWaypointSystem.Main.MOD_ID;
 
 public class Config {
     public final ConfigEntry<AccessLevel> defaultAccess;
-    public final ConfigEntry<Boolean> friendshipEnabled;
     public final ConfigEntry<List<AccessLevel>> disabledAccessLevels;
     public final ConfigEntry<Boolean> preferOpenForDerived;
 
@@ -43,11 +42,6 @@ public class Config {
                 "Sets behaviour on the /wps go <name> shorthand.",
                 "When set to true, first checks for an open waypoint matching <name>,",
                 "otherwise checks for a self-owned waypoint first."
-        );
-        friendshipEnabled = builder.booleanEntry(
-                "enable-friendship",
-                true,
-                "Enable or disable the friendship mechanic"
         );
     }
 

--- a/src/main/java/com/cimadev/cimpleWaypointSystem/FriendsEntrypoint.java
+++ b/src/main/java/com/cimadev/cimpleWaypointSystem/FriendsEntrypoint.java
@@ -9,5 +9,6 @@ public class FriendsEntrypoint implements FischyFriendsEntrypoint {
     @Override
     public void onFriendsInitialised(FriendsAPI friendsAPI) {
         api = friendsAPI;
+        FriendsIntegration.executeDelayedActions();
     }
 }

--- a/src/main/java/com/cimadev/cimpleWaypointSystem/FriendsEntrypoint.java
+++ b/src/main/java/com/cimadev/cimpleWaypointSystem/FriendsEntrypoint.java
@@ -1,0 +1,13 @@
+package com.cimadev.cimpleWaypointSystem;
+
+import de.fisch37.fischyfriends.api.FischyFriendsEntrypoint;
+import de.fisch37.fischyfriends.api.FriendsAPI;
+
+public class FriendsEntrypoint implements FischyFriendsEntrypoint {
+    static FriendsAPI api = null;
+
+    @Override
+    public void onFriendsInitialised(FriendsAPI friendsAPI) {
+        api = friendsAPI;
+    }
+}

--- a/src/main/java/com/cimadev/cimpleWaypointSystem/FriendsIntegration.java
+++ b/src/main/java/com/cimadev/cimpleWaypointSystem/FriendsIntegration.java
@@ -56,6 +56,9 @@ public abstract class FriendsIntegration {
     }
 
     public static boolean areFriends(UUID a, UUID b) {
+        if (a.equals(b))
+            // Self-hate is not part of our user model
+            return true;
         if (isInstalled()) {
             return getAPI().areFriends(a, b);
         } else {

--- a/src/main/java/com/cimadev/cimpleWaypointSystem/FriendsIntegration.java
+++ b/src/main/java/com/cimadev/cimpleWaypointSystem/FriendsIntegration.java
@@ -65,4 +65,10 @@ public abstract class FriendsIntegration {
             return false;
         }
     }
+
+    public static void sendFriendRequest(UUID from, UUID to) {
+        if (isInstalled()) {
+            getAPI().getRequestManager().addFriendRequest(new de.fisch37.fischyfriends.api.FriendRequest(from, to));
+        }
+    }
 }

--- a/src/main/java/com/cimadev/cimpleWaypointSystem/FriendsIntegration.java
+++ b/src/main/java/com/cimadev/cimpleWaypointSystem/FriendsIntegration.java
@@ -1,0 +1,65 @@
+package com.cimadev.cimpleWaypointSystem;
+
+import com.cimadev.cimpleWaypointSystem.command.persistentData.OfflinePlayer;
+import net.fabricmc.loader.api.FabricLoader;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+import static de.fisch37.fischyfriends.FischyFriends.getAPI;
+
+/**
+ *  <h1>IMPORTANT!!!</h1>
+ *  <p>
+ *  This code is <em>very</em> fragile since it has to avoid a crash
+ *  when FischyFriends is not installed.
+ *  <p>
+ *  Try to avoid changing this code if you don't know what you're doing.
+ *  If you do have to change this code:
+ *      <ol>
+ *          <li>Never explicitly reference classes from the API</li>
+ *          <li>Always use <code>isInstalled()</code> before using <code>getAPI()</code></li>
+ *          <li>Some other stuff, idk. Just test afterwards. Test well</li>
+ *      </ol>
+ */
+public abstract class FriendsIntegration {
+    private static final String INTEGRATION = "fischyfriends";
+
+    private static boolean isInstalled() {
+        return FabricLoader.getInstance().isModLoaded(INTEGRATION);
+    }
+
+    public static Collection<UUID> getFriendUuids(UUID uuid) {
+        if (isInstalled()) {
+            return getAPI().getFriends(uuid);
+        } else {
+            return List.of();
+        }
+    }
+    public static Collection<UUID> getFriendUuids(OfflinePlayer player) {
+        return getFriendUuids(player.getUuid());
+    }
+
+    public static Collection<OfflinePlayer> getFriends(UUID uuid) {
+        Collection<UUID> friends = getFriendUuids(uuid);
+
+        ArrayList<OfflinePlayer> friendPlayers = new ArrayList<>(friends.size());
+        for (UUID friend : friends) {
+            friendPlayers.add(Main.serverState.getPlayerByUuid(friend));
+        }
+        return friendPlayers;
+    }
+    public static Collection<OfflinePlayer> getFriends(OfflinePlayer player) {
+        return getFriends(player.getUuid());
+    }
+
+    public static boolean areFriends(UUID a, UUID b) {
+        if (isInstalled()) {
+            return getAPI().areFriends(a, b);
+        } else {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/cimadev/cimpleWaypointSystem/command/WpsCommand.java
+++ b/src/main/java/com/cimadev/cimpleWaypointSystem/command/WpsCommand.java
@@ -204,20 +204,6 @@ public class WpsCommand {
                                         .executes(WpsCommand::wpsSetHome)))
                 );
 
-        if (config.friendshipEnabled.get())
-            command = command.then(
-                    CommandManager.literal("friend")
-                    .then(CommandManager.literal("add")
-                            .then(CommandManager.argument("player", word())
-                                    .suggests(new OfflinePlayerSuggestionProvider())
-                                    .executes(WpsCommand::wpsAddFriend)))
-                    .then(CommandManager.literal("remove")
-                            .then(CommandManager.argument("player", word())
-                                    .suggests(new OfflinePlayerSuggestionProvider())
-                                    .executes(WpsCommand::wpsRemoveFriend)
-                    ))
-            );
-
         dispatcher.register(command);
 
         // administrator wps options
@@ -728,48 +714,6 @@ public class WpsCommand {
                     .formatted(DEFAULT_COLOR);
             messageText = () -> message;
             Main.serverState.markDirty();
-        }
-
-        context.getSource().sendFeedback(messageText, false);
-        return 1;
-    }
-
-    private static int wpsAddFriend(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
-        Supplier<Text> messageText;
-
-        ServerPlayerEntity p = context.getSource().getPlayerOrThrow();
-        OfflinePlayer player = Main.serverState.getPlayerByUuid(p.getUuid());
-        OfflinePlayer friend = OfflinePlayer.fromContext(context, "player");
-        if ( friend != null ) {
-            boolean newFriend = player.addFriend(friend);
-            if ( newFriend ) {
-                messageText = () -> Text.literal("You are now friends with " + friend.getName() + ".").formatted(DEFAULT_COLOR);
-            } else {
-                messageText = () -> Text.literal("You are already friends with " + friend.getName() + "!").formatted(DEFAULT_COLOR);
-            }
-        } else {
-            messageText = () -> Text.literal("The specified player could not be found.").formatted(DEFAULT_COLOR);
-        }
-
-        context.getSource().sendFeedback(messageText, false);
-        return 1;
-    }
-
-    private static int wpsRemoveFriend(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
-        Supplier<Text> messageText;
-
-        ServerPlayerEntity p = context.getSource().getPlayerOrThrow();
-        OfflinePlayer player = Main.serverState.getPlayerByUuid(p.getUuid());
-        OfflinePlayer friend = OfflinePlayer.fromContext(context, "player");
-        if ( friend != null ) {
-            boolean newFriend = player.removeFriend(friend);
-            if ( newFriend ) {
-                messageText = () -> Text.literal("You are no longer friends with " + friend.getName() + ".").formatted(DEFAULT_COLOR);
-            } else {
-                messageText = () -> Text.literal("You weren't friends with " + friend.getName() + "!").formatted(DEFAULT_COLOR);
-            }
-        } else {
-            messageText = () -> Text.literal("The specified player could not be found.").formatted(DEFAULT_COLOR);
         }
 
         context.getSource().sendFeedback(messageText, false);

--- a/src/main/java/com/cimadev/cimpleWaypointSystem/command/persistentData/DataFixer.java
+++ b/src/main/java/com/cimadev/cimpleWaypointSystem/command/persistentData/DataFixer.java
@@ -1,0 +1,112 @@
+package com.cimadev.cimpleWaypointSystem.command.persistentData;
+
+import com.cimadev.cimpleWaypointSystem.FriendsIntegration;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtElement;
+import org.jetbrains.annotations.Contract;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import com.google.common.collect.ImmutableSortedMap;
+
+public class DataFixer {
+    private final static Logger LOGGER = LoggerFactory.getLogger("CWPS/DataFixer");
+    public final static int CURRENT_VERSION = 1;
+
+    /**
+     * Map of Old Data Version -> [(FunctionOutputVersion, FixerFunctions)]
+     * <p>
+     * Where FunctionOutputVersion is always <em>decreasing</em> within a list.
+     * Ideally there should always be a path from any data version to any higher data version.
+     * <p>
+     * The fix algorithm will always choose the largest jump possible.
+     * It is up to developers to ensure that functions that skip versions will still allow updates to (any higher version).
+     */
+    private final static Map<Integer, ImmutableSortedMap<Integer, FixerFunction>> FIXER_MAP = Map.of(
+            0, ImmutableSortedMap.of(
+                    1, DataFixer::FIX_transferFriendsToIntegration
+            )
+    );
+
+    /**
+     * Ensures that this tag is marked with the current version.
+     * @param tag The tag to modify
+     */
+    public static void setToCurrentVersion(NbtCompound tag) {
+        tag.putInt("data_version", CURRENT_VERSION);
+    }
+
+    public static NbtCompound fixData(NbtCompound data) {
+        int dataVersion = data.getInt("data_version");
+        if (dataVersion == CURRENT_VERSION) {
+            return data;
+        } else if (dataVersion > CURRENT_VERSION) {
+            LOGGER.error("Downgrade dectected! Downgrades are not supported and will lead to bugs, data loss, and/or crashes");
+            return data;
+        }
+
+        LOGGER.info("Updating data from version {} to version {}", dataVersion, CURRENT_VERSION);
+        ImmutableSortedMap<Integer, FixerFunction> fixes = FIXER_MAP.get(dataVersion);
+        Map.Entry<Integer, FixerFunction> fix = fixes.entrySet()
+                .stream()
+                .filter(entry -> entry.getKey() <= CURRENT_VERSION)
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("No valid fixer found for " + dataVersion + " -> " + CURRENT_VERSION));
+        int outputVersion = fix.getKey();
+        FixerFunction function = fix.getValue();
+        NbtCompound fixed = applyFix(data, outputVersion, function);
+        return fixData(fixed); // This doesn't loop infinitely because of the exit-condition above :)
+    }
+
+    private static NbtCompound applyFix(NbtCompound data, int outputVersion, FixerFunction function) {
+        NbtCompound fixedData = data.copy();
+        function.fix(fixedData);
+        fixedData.putInt("data_version", outputVersion);
+        return fixedData;
+    }
+
+    @FunctionalInterface
+    private interface FixerFunction {
+        @Contract(mutates = "param")  // This is non-experimental as of annotations 26
+        void fix(NbtCompound data);
+    }
+
+
+    /*
+     * Put all FixerFunctions here. FixerFunctions should always be private, static and begin with "FIX_".
+     * Since they are void methods, they mutate their parameter.
+     */
+
+    /**
+     * Transfers old-style friends into the FischyFriends mod (if available)
+     * This fix is a bit wonky in that the transfer will only work if the mod is installed at first launch
+     * (with this version).
+     * Otherwise, the data will be lost.
+     */
+    private static void FIX_transferFriendsToIntegration(NbtCompound input) {
+        input.getList("playerList", NbtElement.COMPOUND_TYPE).forEach(nbt -> {
+            NbtCompound playerData = (NbtCompound) nbt;
+            NbtCompound friendsList = playerData.getCompound("friendList"); // Yes this is correct
+            UUID player = playerData.getUuid("uuid");
+            // friendList is a compound and follows this pattern:
+            /*
+              friend1 -> friend2
+              friend3 -> friend4
+                     ...
+              friendN -> friendN (only if odd)
+             */
+            // This means every key corresponds to (usually) 2 friends
+            // Since it won't cause any problems (I hope) we can ignore that usually and maybe issue two equal requests
+            friendsList.getKeys()
+                    .stream()
+                    .flatMap(key -> Stream.of(key, friendsList.getString(key)))
+                    .map(UUID::fromString)
+                    .forEach(targetFriend -> FriendsIntegration.sendFriendRequest(player, targetFriend));
+            playerData.remove("friendList");
+        });
+    }
+}

--- a/src/main/java/com/cimadev/cimpleWaypointSystem/command/persistentData/OfflinePlayer.java
+++ b/src/main/java/com/cimadev/cimpleWaypointSystem/command/persistentData/OfflinePlayer.java
@@ -10,7 +10,6 @@ import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.Text;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.TreeSet;
 import java.util.UUID;
 
 import static com.cimadev.cimpleWaypointSystem.Main.DEFAULT_COLOR;
@@ -25,7 +24,6 @@ public class OfflinePlayer implements Comparable<OfflinePlayer> {
 
     private final UUID uuid;
     private String name;
-    private final TreeSet<UUID> friends = new TreeSet<>();
 
     public UUID getUuid() {
         return this.uuid;
@@ -41,14 +39,6 @@ public class OfflinePlayer implements Comparable<OfflinePlayer> {
 
     public void emptyName() {
         this.name = "";
-    }
-
-    public boolean addFriend(OfflinePlayer friend) {
-        return friends.add(friend.getUuid());
-    }
-
-    public boolean removeFriend(OfflinePlayer notFriend) {
-        return friends.remove(notFriend.getUuid());
     }
 
     @Override
@@ -70,35 +60,12 @@ public class OfflinePlayer implements Comparable<OfflinePlayer> {
     OfflinePlayer( NbtCompound nbt ) {
         this.uuid = nbt.getUuid( "uuid" ); /*todo: check invalid uuid*/
         this.name = nbt.getString( "name" );
-
-        NbtCompound friendList = nbt.getCompound("friendList");
-        friendList.getKeys().forEach(key -> {
-            this.friends.add( UUID.fromString(key) );
-            this.friends.add( UUID.fromString(friendList.getString(key)) );
-        });
-    }
-
-    public boolean likes(UUID maybeFriend) {
-        if ( maybeFriend.equals(uuid) ) return true;
-        return friends.contains(maybeFriend);
     }
 
     public NbtCompound toNbt( ) {
         NbtCompound nbt = new NbtCompound();
         nbt.putUuid("uuid", uuid);
         nbt.putString("name", name);
-        int friendnum = friends.size();
-
-        NbtCompound friendList = new NbtCompound();
-        while( friends.size() > 1 ) {
-            friendList.putString( friends.pollFirst().toString() , friends.pollLast().toString() );
-        }
-        if (friendnum == 1) {
-            String lastUuid = friends.pollFirst().toString();
-            friendList.putString(lastUuid, lastUuid);
-        }
-
-        nbt.put("friendList", friendList);
         return nbt;
     }
 

--- a/src/main/java/com/cimadev/cimpleWaypointSystem/command/persistentData/ServerState.java
+++ b/src/main/java/com/cimadev/cimpleWaypointSystem/command/persistentData/ServerState.java
@@ -1,5 +1,6 @@
 package com.cimadev.cimpleWaypointSystem.command.persistentData;
 
+import com.cimadev.cimpleWaypointSystem.FriendsIntegration;
 import com.cimadev.cimpleWaypointSystem.Main;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtElement;
@@ -90,7 +91,7 @@ public class ServerState extends PersistentState {
         // waypoint only visible by admins by listing all waypoints
         if ( owner == null ) return false;
 
-        if ( waypoint.getAccess() == AccessLevel.PRIVATE && owner.likes( playerUuid ) ) {
+        if ( waypoint.getAccess() == AccessLevel.PRIVATE && FriendsIntegration.areFriends(owner.getUuid(), playerUuid) ) {
             return true;
         }
 

--- a/src/main/java/com/cimadev/cimpleWaypointSystem/command/persistentData/ServerState.java
+++ b/src/main/java/com/cimadev/cimpleWaypointSystem/command/persistentData/ServerState.java
@@ -148,10 +148,14 @@ public class ServerState extends PersistentState {
         playerHomes.values().forEach( playerHome -> playerHomesList.add(playerHome.toNbt()) );
         nbt.put("playerHomes", playerHomesList);
 
+        DataFixer.setToCurrentVersion(nbt);
+
         return nbt;
     }
 
     public static ServerState createFromNbt(NbtCompound tag, RegistryWrapper.WrapperLookup registryLookup) {
+        tag = DataFixer.fixData(tag);
+
         ServerState serverState = new ServerState();
         NbtList pList = tag.getList("playerList", NbtElement.COMPOUND_TYPE);
         pList.forEach( nbt -> serverState.loadPlayer( OfflinePlayer.fromNbt((NbtCompound) nbt)) );

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,5 +28,8 @@
 		"minecraft": "~1.21",
 		"java": ">=17",
 		"fabric-api": "*"
+	},
+	"recommends": {
+		"fischyfriends": "~1.0"
 	}
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -18,6 +18,9 @@
 	"entrypoints": {
 		"main": [
 			"com.cimadev.cimpleWaypointSystem.Main"
+		],
+		"fischy_friends": [
+			"com.cimadev.cimpleWaypointSystem.FriendsEntrypoint"
 		]
 	},
 	"mixins": [


### PR DESCRIPTION
Eh we decided to export the friends stuff into a separate API mod so this PR makes an optional (recommended) dependency on [Fischy Friends](https://modrinth.com/mod/fischy-friends). Without it access level `private` is treated the same as `secret`.

Right now this means that old friendships will not be transferred.

Update: A custom datafixer has been implemented that transfers the old friendships to friend requests in Fischy Friends (or full friendships if they are bilateral). However, the datafixer will delete the old friendships if Fischy Friends is not installed at update time